### PR TITLE
Make verbose flag work through API on both mesh pipeline and postprocessing

### DIFF
--- a/trellis/pipelines/trellis_image_to_3d.py
+++ b/trellis/pipelines/trellis_image_to_3d.py
@@ -166,6 +166,7 @@ class TrellisImageTo3DPipeline(Pipeline):
         cond: dict,
         num_samples: int = 1,
         sampler_params: dict = {},
+        verbose: bool = True,
     ) -> torch.Tensor:
         """
         Sample sparse structures with the given conditioning.
@@ -185,7 +186,7 @@ class TrellisImageTo3DPipeline(Pipeline):
             noise,
             **cond,
             **sampler_params,
-            verbose=True
+            verbose=verbose
         ).samples
         
         # Decode occupancy latent
@@ -223,6 +224,7 @@ class TrellisImageTo3DPipeline(Pipeline):
         cond: dict,
         coords: torch.Tensor,
         sampler_params: dict = {},
+        verbose: bool = True,
     ) -> sp.SparseTensor:
         """
         Sample structured latent with the given conditioning.
@@ -244,7 +246,7 @@ class TrellisImageTo3DPipeline(Pipeline):
             noise,
             **cond,
             **sampler_params,
-            verbose=True
+            verbose=verbose
         ).samples
 
         std = torch.tensor(self.slat_normalization['std'])[None].to(slat.device)
@@ -263,6 +265,7 @@ class TrellisImageTo3DPipeline(Pipeline):
         slat_sampler_params: dict = {},
         formats: List[str] = ['mesh', 'gaussian', 'radiance_field'],
         preprocess_image: bool = True,
+        verbose: bool = True,
     ) -> dict:
         """
         Run the pipeline.
@@ -278,6 +281,6 @@ class TrellisImageTo3DPipeline(Pipeline):
             image = self.preprocess_image(image)
         cond = self.get_cond([image])
         torch.manual_seed(seed)
-        coords = self.sample_sparse_structure(cond, num_samples, sparse_structure_sampler_params)
-        slat = self.sample_slat(cond, coords, slat_sampler_params)
+        coords = self.sample_sparse_structure(cond, num_samples, sparse_structure_sampler_params, verbose)
+        slat = self.sample_slat(cond, coords, slat_sampler_params, verbose)
         return self.decode_slat(slat, formats)

--- a/trellis/utils/postprocessing_utils.py
+++ b/trellis/utils/postprocessing_utils.py
@@ -187,7 +187,7 @@ def _fill_holes(
         if verbose:
             tqdm.write(f'Removed 0 faces by mincut')
             
-    mesh = _meshfix.PyTMesh()
+    mesh = _meshfix.PyTMesh(verbose=verbose)
     mesh.load_array(verts.cpu().numpy(), faces.cpu().numpy())
     mesh.fill_small_boundaries(nbe=max_hole_nbe, refine=True)
     verts, faces = mesh.return_arrays()
@@ -439,7 +439,7 @@ def to_glb(
     vertices, faces, uvs = parametrize_mesh(vertices, faces)
 
     # bake texture
-    observations, extrinsics, intrinsics = render_multiview(app_rep, resolution=1024, nviews=100)
+    observations, extrinsics, intrinsics = render_multiview(app_rep, resolution=1024, nviews=100, verbose=verbose)
     masks = [np.any(observation > 0, axis=-1) for observation in observations]
     extrinsics = [extrinsics[i].cpu().numpy() for i in range(len(extrinsics))]
     intrinsics = [intrinsics[i].cpu().numpy() for i in range(len(intrinsics))]

--- a/trellis/utils/render_utils.py
+++ b/trellis/utils/render_utils.py
@@ -96,14 +96,14 @@ def render_video(sample, resolution=512, bg_color=(0, 0, 0), num_frames=300, r=2
     return render_frames(sample, extrinsics, intrinsics, {'resolution': resolution, 'bg_color': bg_color}, **kwargs)
 
 
-def render_multiview(sample, resolution=512, nviews=30):
+def render_multiview(sample, resolution=512, nviews=30, **kwargs):
     r = 2
     fov = 40
     cams = [sphere_hammersley_sequence(i, nviews) for i in range(nviews)]
     yaws = [cam[0] for cam in cams]
     pitchs = [cam[1] for cam in cams]
     extrinsics, intrinsics = yaw_pitch_r_fov_to_extrinsics_intrinsics(yaws, pitchs, r, fov)
-    res = render_frames(sample, extrinsics, intrinsics, {'resolution': resolution, 'bg_color': (0, 0, 0)})
+    res = render_frames(sample, extrinsics, intrinsics, {'resolution': resolution, 'bg_color': (0, 0, 0)}, **kwargs)
     return res['color'], extrinsics, intrinsics
 
 


### PR DESCRIPTION
There were few things that got missed by the verbose flag, and pipeline didn't even expose the setting through API.
With verbose set to False on both of these, nothing gets reported on console on normal operation.

PS. I do feel that there could be additional info etc flag though that would report just currently ongoing operations and show the progress indicators, but leave all the more verbose messaging out, but that's beyond the scope of this PR.