### PR TITLE
In preprocess_image, using consistent cutoff value for bounding box and pre-multiplied alpha

### DIFF
--- a/trellis/pipelines/trellis_image_to_3d.py
+++ b/trellis/pipelines/trellis_image_to_3d.py
@@ -105,7 +105,8 @@ class TrellisImageTo3DPipeline(Pipeline):
             output = rembg.remove(input, session=self.rembg_session)
         output_np = np.array(output)
         alpha = output_np[:, :, 3]
-        bbox = np.argwhere(alpha > 0.8 * 255)
+        alpha_cutoff = 0.8
+        bbox = np.argwhere(alpha > alpha_cutoff * 255)
         bbox = np.min(bbox[:, 1]), np.min(bbox[:, 0]), np.max(bbox[:, 1]), np.max(bbox[:, 0])
         center = (bbox[0] + bbox[2]) / 2, (bbox[1] + bbox[3]) / 2
         size = max(bbox[2] - bbox[0], bbox[3] - bbox[1])
@@ -114,7 +115,7 @@ class TrellisImageTo3DPipeline(Pipeline):
         output = output.crop(bbox)  # type: ignore
         output = output.resize((518, 518), Image.Resampling.LANCZOS)
         output = np.array(output).astype(np.float32) / 255
-        output = output[:, :, :3] * output[:, :, 3:4]
+        output = output[:, :, :3] * (output[:, :, 3:4] > alpha_cutoff)
         output = Image.fromarray((output * 255).astype(np.uint8))
         return output
 


### PR DESCRIPTION
The alpha from rembg is not binary. A small foreground object make causing a transition region around the object due to resizing. Binarize the alpha channel with a cutoff value fixes the problem. Also, this cutoff is used in bounding box selection.

Here is an example. Before this change, a wide transition of alpha from 0 to 1 causing the system can't distinguish the foreground and background. The result is a quad shape.
![image](https://github.com/user-attachments/assets/cfffec7c-e566-4f82-91f7-72e4ba027cc3)

After this change, it's much better in 3D shape.
![image](https://github.com/user-attachments/assets/2952adf8-c32e-4834-b418-194ddf2d2d3c)

