### PR TITLE
Fix RuntimeError on HF Demo ; 

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,6 +13,9 @@ from trellis.pipelines import TrellisImageTo3DPipeline
 from trellis.representations import Gaussian, MeshExtractResult
 from trellis.utils import render_utils, postprocessing_utils
 
+# initialize pipeline at module level
+pipeline = TrellisImageTo3DPipeline.from_pretrained("microsoft/TRELLIS-image-large")
+pipeline.cuda()
 
 MAX_SEED = np.iinfo(np.int32).max
 TMP_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'tmp')
@@ -398,6 +401,4 @@ with gr.Blocks(delete_cache=(600, 600)) as demo:
 
 # Launch the Gradio app
 if __name__ == "__main__":
-    pipeline = TrellisImageTo3DPipeline.from_pretrained("microsoft/TRELLIS-image-large")
-    pipeline.cuda()
     demo.launch()


### PR DESCRIPTION
hello, was going through img to 3d / mesh online and found the demo with the paper however I see this 
Error:
 `File "/home/user/app/app.py", line 44, in preprocess_image
    processed_image = pipeline.preprocess_image(image)
NameError: name 'pipeline' is not defined` 

Fix : when Gradio tries to cache examples by moving the pipeline init from main block to module level

