### PR TITLE
change the hard-coded batch size to a configurable parameter when tra…

### DIFF
--- a/trellis/trainers/base.py
+++ b/trellis/trainers/base.py
@@ -230,7 +230,7 @@ class Trainer:
 
         # Assign tasks
         num_samples_per_process = int(np.ceil(num_samples / self.world_size))
-        samples = self.run_snapshot(num_samples_per_process, batch_size=batch_size, verbose=verbose)
+        samples = self.run_snapshot(num_samples_per_process, batch_size=self.batch_size_per_gpu, verbose=verbose)
 
         # Preprocess images
         for key in list(samples.keys()):


### PR DESCRIPTION
 The batch size is hard-coded as 4, this PR change the hard-coded batch size to a configurable parameter when training ss_flow_img_dit_L_16l8_fp16.json
