### PR TITLE
[Fix]: Ignore Unicode encoding errors when reading metadata.csv

### DIFF
--- a/dataset_toolkits/download.py
+++ b/dataset_toolkits/download.py
@@ -52,4 +52,5 @@ if __name__ == '__main__':
 
     # process objects
     downloaded = dataset_utils.download(metadata, **opt)
-    downloaded.to_csv(os.path.join(opt.output_dir, f'downloaded_{opt.rank}.csv'), index=False)
+    with open(os.path.join(opt.output_dir, f'downloaded_{opt.rank}.csv'), 'w', encoding='utf-8', errors='ignore') as f:
+        downloaded.to_csv(f, index=False)


### PR DESCRIPTION
What does this PR do?
---
This PR fixes an issue where a UnicodeEncodeError occurred while reading metadata.csv due to the presence of invalid Unicode surrogate characters.
To prevent the error, the file is now opened using errors='ignore', which skips over problematic characters during decoding.
This ensures robust CSV loading even when metadata contains malformed or unexpected Unicode.