### PR TITLE
Update launch to accept ENV for greater deployment compatibility

### DIFF
--- a/ENV_CONFIG.md
+++ b/ENV_CONFIG.md
@@ -16,9 +16,6 @@ These are handled directly in `app.py` and `app_text.py`:
 ## Usage
 
 ```bash
-# Basic usage with defaults
-python3 app.py
-
 # Custom configuration
 export GRADIO_SERVER_NAME=0.0.0.0
 export GRADIO_SERVER_PORT=8080

--- a/ENV_CONFIG.md
+++ b/ENV_CONFIG.md
@@ -1,0 +1,27 @@
+# TRELLIS Environment Variable Configuration
+
+## Overview
+
+The TRELLIS apps now support environment variable configuration for Gradio server settings.
+
+## Environment Variables
+
+### Gradio Server Configuration
+These are handled directly in `app.py` and `app_text.py`:
+
+- `GRADIO_SERVER_NAME` (default: `0.0.0.0`) - Server binding address
+- `GRADIO_SERVER_PORT` (default: `7860`) - Server port  
+- `GRADIO_SHARE` (default: `false`) - Enable public sharing
+
+## Usage
+
+```bash
+# Basic usage with defaults
+python3 app.py
+
+# Custom configuration
+export GRADIO_SERVER_NAME=0.0.0.0
+export GRADIO_SERVER_PORT=8080
+export GRADIO_SHARE=true
+python3 app.py
+```

--- a/app.py
+++ b/app.py
@@ -14,6 +14,8 @@ from trellis.representations import Gaussian, MeshExtractResult
 from trellis.utils import render_utils, postprocessing_utils
 
 
+
+
 MAX_SEED = np.iinfo(np.int32).max
 TMP_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'tmp')
 os.makedirs(TMP_DIR, exist_ok=True)
@@ -400,4 +402,8 @@ with gr.Blocks(delete_cache=(600, 600)) as demo:
 if __name__ == "__main__":
     pipeline = TrellisImageTo3DPipeline.from_pretrained("microsoft/TRELLIS-image-large")
     pipeline.cuda()
-    demo.launch()
+    demo.launch(
+        server_name=os.environ.get('GRADIO_SERVER_NAME', '0.0.0.0'),
+        server_port=int(os.environ.get('GRADIO_SERVER_PORT', '7860')),
+        share=os.environ.get('GRADIO_SHARE', 'false').lower() == 'true'
+    )

--- a/app.py
+++ b/app.py
@@ -14,8 +14,6 @@ from trellis.representations import Gaussian, MeshExtractResult
 from trellis.utils import render_utils, postprocessing_utils
 
 
-
-
 MAX_SEED = np.iinfo(np.int32).max
 TMP_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'tmp')
 os.makedirs(TMP_DIR, exist_ok=True)

--- a/app_text.py
+++ b/app_text.py
@@ -13,6 +13,8 @@ from trellis.representations import Gaussian, MeshExtractResult
 from trellis.utils import render_utils, postprocessing_utils
 
 
+
+
 MAX_SEED = np.iinfo(np.int32).max
 TMP_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'tmp')
 os.makedirs(TMP_DIR, exist_ok=True)
@@ -263,4 +265,8 @@ with gr.Blocks(delete_cache=(600, 600)) as demo:
 if __name__ == "__main__":
     pipeline = TrellisTextTo3DPipeline.from_pretrained("microsoft/TRELLIS-text-xlarge")
     pipeline.cuda()
-    demo.launch()
+    demo.launch(
+        server_name=os.environ.get('GRADIO_SERVER_NAME', '0.0.0.0'),
+        server_port=int(os.environ.get('GRADIO_SERVER_PORT', '7860')),
+        share=os.environ.get('GRADIO_SHARE', 'false').lower() == 'true'
+    )

--- a/app_text.py
+++ b/app_text.py
@@ -13,8 +13,6 @@ from trellis.representations import Gaussian, MeshExtractResult
 from trellis.utils import render_utils, postprocessing_utils
 
 
-
-
 MAX_SEED = np.iinfo(np.int32).max
 TMP_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'tmp')
 os.makedirs(TMP_DIR, exist_ok=True)


### PR DESCRIPTION
While trying to launch TRELLIS in a containerized environment I ran into issues where the application couldn't bind to local host. With no way to override this through ENV values I discovered a simple modification would allow us to pass values set in the ENV to the application on launch. 

Here is the practical application of this change in a project I've been working on. 
https://github.com/pixeloven/TRELLIS-Docker/pull/3/files (See the use of submodule with this change present)

These videos showcase the patch in use by this project.
[build-step.webm](https://github.com/user-attachments/assets/5e6d0bdb-1141-4c12-a6de-ec10b6e27005)
[runtime-step.webm](https://github.com/user-attachments/assets/c1dbb373-1e15-4ae5-8ef2-9fcfbacac823)


@microsoft-github-policy-service agree