### PR TITLE
Add community Apple Silicon (MPS) port reference to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 ## 📦 Installation
 
 ### Prerequisites
-- **System**: The code is currently tested only on **Linux**.  For windows setup, you may refer to [#3](https://github.com/microsoft/TRELLIS/issues/3) (not fully tested).
+- **System**: The code is currently tested only on **Linux**.  For windows setup, you may refer to [#3](https://github.com/microsoft/TRELLIS/issues/3) (not fully tested). For **Apple Silicon Macs (no CUDA/Linux)**, see the community port [trellis-mac-mps](https://github.com/vinayapathak/trellis-mac-mps) — every CUDA-only extension replaced with a native PyTorch/MPS or hand-written Metal equivalent, plus benchmarked kernel-, algorithm-, and architecture-level optimization results; addresses [#154](https://github.com/microsoft/TRELLIS/issues/154), [#96](https://github.com/microsoft/TRELLIS/issues/96), [#51](https://github.com/microsoft/TRELLIS/issues/51), [#303](https://github.com/microsoft/TRELLIS/issues/303).
 - **Hardware**: An NVIDIA GPU with at least 16GB of memory is necessary. The code has been verified on NVIDIA A100 and A6000 GPUs.  
 - **Software**:   
   - The [CUDA Toolkit](https://developer.nvidia.com/cuda-toolkit-archive) is needed to compile certain submodules. The code has been tested with CUDA versions 11.8 and 12.2.  


### PR DESCRIPTION
## Summary

Several open issues ask whether/how TRELLIS can run on Apple Silicon Macs without CUDA:
#154, #96, #51, #303. This adds a single-line pointer in the Prerequisites section to
[trellis-mac-mps](https://github.com/vinayapathak/trellis-mac-mps), a community port that runs
the full pipeline natively on Apple Silicon (M-series) via PyTorch's MPS backend, with no CUDA
Toolkit and no Linux required.

What the port covers, briefly:
- Every CUDA-only extension in the original pipeline (sparse convolution, the differentiable
  rasterizer, the Gaussian splat renderer) replaced with a pure-PyTorch/MPS implementation or a
  hand-written Metal compute kernel.
- A local web UI and CLI in addition to the original Gradio demo.
- Real, repeated-trial-measured kernel-, algorithm-, and architecture-level performance results
  (not just "it runs") — real speedups from an algorithmic classifier-free-guidance caching fix
  and training-free step-count reduction, a characterization of where hand-written Metal kernels
  do and don't beat PyTorch's native MPS backend, and a windowed-attention architecture change
  with a distillation-based quality validation. Full write-up in the port's own `APPLE_SILICON.md`
  and an accompanying paper.
- Passing CI on Apple Silicon GitHub runners for the full test suite.

## Scope

Documentation only — a single line added to the Prerequisites section, no functional changes to
this repo. Happy to adjust placement/wording, or fold this into an existing community-links
section if one is preferred, if maintainers have a different convention in mind.